### PR TITLE
fix: change module name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module go-vector-logger
+module github.com/scor2k/go-vector-logger
 
 go 1.20


### PR DESCRIPTION
Can't update the module from my project: 
`❯ go get github.com/scor2k/go-vector-logger@v0.7.1
go: github.com/scor2k/go-vector-logger@v0.7.1 requires github.com/scor2k/go-vector-logger@v0.7.1: parsing go.mod:
        module declares its path as: go-vector-logger
                but was required as: github.com/scor2k/go-vector-logger`